### PR TITLE
typo fix in README: maur->maru

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ MaruSwagger
 
 NOTE: `maru_swagger` is only works for `:dev`
 
-Please keep `MaurSwagger` plug out of `version` dsl.
+Please keep `MaruSwagger` plug out of `version` dsl.
 
 ```elixir
 def deps do


### PR DESCRIPTION
Just a small typo fix in the readme.

Cheers