### PR TITLE
Allow securityDefinitions and security in swagger_inject

### DIFF
--- a/lib/maru_swagger/config_struct.ex
+++ b/lib/maru_swagger/config_struct.ex
@@ -72,7 +72,7 @@ defmodule MaruSwagger.ConfigStruct do
   end
 
   defp allowed_swagger_fields do
-    [:host, :basePath, :schemes, :consumes, :produces]
+    [:host, :basePath, :schemes, :consumes, :produces, :securityDefinitions, :security]
   end
 
   defp check_info_inject_keys(info) do


### PR DESCRIPTION
Allow specifying authorization methods in use, as described in
https://swagger.io/docs/specification/2-0/authentication/api-keys/